### PR TITLE
Fixes for Issues #19, #23, #31, #32 and #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # OctoPrint Klipper Plugin
 
+## Fork information:
+- Current version JEL-0.1
+- Changes to klipper.js, klipper_param_macro.js, and klipper_leveling.js to send
+  multiple GCode commands to OctoPrint.control.sendGcode as arrays of strings 
+  instead of a single strings with line breaks or other formatting, which is not 
+  interpreted correctly.  
+
 This plugin assists in managing and monitoring the [Klipper](https://github.com/KevinOConnor/klipper) 3D printer firmware.
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
-# OctoPrint Klipper Plugin
-
 ## Fork information:
-- Current version JEL-0.1
-- Changes to klipper.js, klipper_param_macro.js, and klipper_leveling.js to send
-  multiple GCode commands to OctoPrint.control.sendGcode as arrays of strings 
-  instead of a single strings with line breaks or other formatting, which is not 
-  interpreted correctly.  
+- This is forked from [the original](https://github.com/mmone/OctoprintKlipperPlugin) version 0.2.5
+- The current version is 0.2.5-JEL-0.1 and includes modified versions of:
+  - klipper.js
+  - klipper_param_macro.js
+  - klipper_leveling.js
+- Changes made result in multiple GCode commands being sent to OctoPrint.control.sendGcode as an array of strings instead of separate strings or as strings with line breaks or other formatting.  This results in the commands being received in the intended order and interpreted correctly. 
 
+## Fork Installation Information:
+- Uninstall any other versions of the plugin using Plugin Manager or other means, as necessary.
+- Install this version by using Plugin Manager's "From Url" option and entering this URL:
+`https://github.com/jameseleach/OctoprintKlipperPlugin/archive/JEL-0.1.zip`
+
+Original contents follow...
+
+# OctoPrint Klipper Plugin
 This plugin assists in managing and monitoring the [Klipper](https://github.com/KevinOConnor/klipper) 3D printer firmware.
 
-### Features
+## Features
 - Simplified connection dialog.
 - Restart Host and MCU processes.
 - User defineable macro buttons with optional parameter dialogs.

--- a/octoprint_klipper/__init__.py
+++ b/octoprint_klipper/__init__.py
@@ -92,6 +92,10 @@ class KlipperPlugin(
             filepath = os.path.expanduser(
                self._settings.get(["configuration", "path"])
             )
+            # Check for Unicode config file and convert to String, if so.
+            if type(data["config"]) == unicode:
+               data["config"] = data["config"].encode('utf-8')
+
             f = open(filepath, "w")
             f.write(data["config"])
             f.close()

--- a/octoprint_klipper/static/js/klipper.js
+++ b/octoprint_klipper/static/js/klipper.js
@@ -58,7 +58,9 @@ $(function() {
            
            if (macro.macro().match(paramObjRegex) == null) {
               OctoPrint.control.sendGcode(
-                 macro.macro().replace(/(?:\r\n|\r|\n)/g, " ")
+                 // Use .split to create an array of strings which is sent to 
+                 // OctoPrint.control.sendGcode instead of a single string.
+                 macro.macro().split(/\r\n|\r|\n/)
               );
            } else {
               self.paramMacroViewModel.process(macro);

--- a/octoprint_klipper/static/js/klipper_leveling.js
+++ b/octoprint_klipper/static/js/klipper_leveling.js
@@ -58,19 +58,18 @@ $(function() {
         }
         */
         self.moveToPosition = function(x, y) {
-           OctoPrint.control.sendGcode( 
+           OctoPrint.control.sendGcode([
+              // Move Z up 
               "G1 Z" + (self.settings.settings.plugins.klipper.probe.height() * 1 + 
               self.settings.settings.plugins.klipper.probe.lift()*1) +
-              " F" + self.settings.settings.plugins.klipper.probe.speed_z()
-           );
-           OctoPrint.control.sendGcode(
+              " F" + self.settings.settings.plugins.klipper.probe.speed_z() ,
+              // Move XY
               "G1 X" + x + " Y" + y +
-              " F" + self.settings.settings.plugins.klipper.probe.speed_xy()
-           );
-           OctoPrint.control.sendGcode(
+              " F" + self.settings.settings.plugins.klipper.probe.speed_xy() ,
+              // Move Z down
               "G1 Z" + self.settings.settings.plugins.klipper.probe.height() +
                " F" + self.settings.settings.plugins.klipper.probe.speed_z()
-           );
+           ]);
         }
         
         self.moveToPoint = function(index) {

--- a/octoprint_klipper/static/js/klipper_param_macro.js
+++ b/octoprint_klipper/static/js/klipper_param_macro.js
@@ -62,8 +62,9 @@ $(function() {
            }
            
            expanded = self.macro.replace(paramObjRegex, replaceParams)
-           expanded = expanded.replace(/(?:\r\n|\r|\n)/g, " ");
-           
+           expanded = "[\"" + expanded + "\"]"
+           expanded = expanded.replace(/(?:\r\n|\r|\n)/g, "\",\"");
+
            OctoPrint.control.sendGcode(expanded);
         }
     }

--- a/octoprint_klipper/static/js/klipper_param_macro.js
+++ b/octoprint_klipper/static/js/klipper_param_macro.js
@@ -60,11 +60,9 @@ $(function() {
               i++;
               return self.parameters()[i]["value"];
            }
-           
+           // Use .split to create an array of strings which is sent to 
+           // OctoPrint.control.sendGcode instead of a single string.
            expanded = self.macro.replace(paramObjRegex, replaceParams)
-//           expanded = "[\"" + expanded + "\"]"
-//           expanded = expanded.replace(/(?:\r\n|\r|\n)/g, "\",\"");
-           // Split using RegEx - cleaner
            expanded = expanded.split(/\r\n|\r|\n/);
 
            OctoPrint.control.sendGcode(expanded);

--- a/octoprint_klipper/static/js/klipper_param_macro.js
+++ b/octoprint_klipper/static/js/klipper_param_macro.js
@@ -65,7 +65,8 @@ $(function() {
            expanded = "[\"" + expanded + "\"]"
            expanded = expanded.replace(/(?:\r\n|\r|\n)/g, "\",\"");
 
-           OctoPrint.control.sendGcode(expanded);
+//           OctoPrint.control.sendGcode(expanded);
+           OctoPrint.control.sendGcode(["G28","G28"])
         }
     }
 

--- a/octoprint_klipper/static/js/klipper_param_macro.js
+++ b/octoprint_klipper/static/js/klipper_param_macro.js
@@ -65,8 +65,7 @@ $(function() {
            expanded = "[\"" + expanded + "\"]"
            expanded = expanded.replace(/(?:\r\n|\r|\n)/g, "\",\"");
 
-//           OctoPrint.control.sendGcode(expanded);
-           OctoPrint.control.sendGcode(["G28","G28"])
+           OctoPrint.control.sendGcode(expanded);
         }
     }
 

--- a/octoprint_klipper/static/js/klipper_param_macro.js
+++ b/octoprint_klipper/static/js/klipper_param_macro.js
@@ -62,8 +62,10 @@ $(function() {
            }
            
            expanded = self.macro.replace(paramObjRegex, replaceParams)
-           expanded = "[\"" + expanded + "\"]"
-           expanded = expanded.replace(/(?:\r\n|\r|\n)/g, "\",\"");
+//           expanded = "[\"" + expanded + "\"]"
+//           expanded = expanded.replace(/(?:\r\n|\r|\n)/g, "\",\"");
+           // Split using RegEx - cleaner
+           expanded = expanded.split(/\r\n|\r|\n/);
 
            OctoPrint.control.sendGcode(expanded);
         }

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ plugin_package = "octoprint_klipper"
 
 plugin_name = "OctoKlipper"
 
-plugin_version = "0.2.5"
+plugin_version = "0.2.5-JEL-0.1"
 
 plugin_description = """A plugin for OctoPrint to configure,control and monitor the Klipper 3D printer software."""
 


### PR DESCRIPTION
Send the three GCode commands with one OctoPrintClient.control.sendGcode
command by sending an array of strings instead of three separate commands
with individual strings.

This ensures that the three move commands are always processed in order.